### PR TITLE
Daemon - ssids

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -15,14 +15,17 @@ func main() {
 	ssidsFile := os.Getenv("SNAP_COMMON") + "/ssids"
 	for {
 		SSIDs, _, _ := c.Ssids()
-		var out string
-		for _, ssid := range SSIDs {
-			out += strings.TrimSpace(ssid.Ssid) + ","
-		}
-		out = out[:len(out)-1]
-		err := ioutil.WriteFile(ssidsFile, []byte(out), 0644)
-		if err != nil {
-			fmt.Println("Error writing ssids to ", ssidsFile)
+		//only write SSIDs when found
+		if len(SSIDs) > 0 {
+			var out string
+			for _, ssid := range SSIDs {
+				out += strings.TrimSpace(ssid.Ssid) + ","
+			}
+			out = out[:len(out)-1]
+			err := ioutil.WriteFile(ssidsFile, []byte(out), 0644)
+			if err != nil {
+				fmt.Println("Error writing ssids to ", ssidsFile)
+			}
 		}
 		// wait 5 seconds
 		time.Sleep(5000 * time.Millisecond)

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -30,5 +30,4 @@ func main() {
 		// wait 5 seconds
 		time.Sleep(5000 * time.Millisecond)
 	}
-	return
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	//"bufio"
+	//"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/CanonicalLtd/UCWifiConnect/netman"
+)
+
+/*
+type options struct {
+	devel bool
+}
+
+func args() *options {
+	opts := &options{}
+	flag.BoolVar(&opts.devel, "devel", false, "Test a hard coded devel path")
+	return opts
+}
+*/
+func main() {
+	c := netman.DefaultClient()
+	/*
+		opts := args()
+			if opts.devel {
+				dvs := c.GetDevices()
+				dwvs := c.GetWifiDevices(dvs)
+				for _, d := range dwvs {
+					fmt.Println(d)
+				}
+				return
+			}
+	*/
+	ssidsFile := os.Getenv("SNAP_COMMON") + "/ssids"
+	for {
+		fmt.Println("==== iter")
+		time.Sleep(200 * time.Millisecond)
+		SSIDs, _, _ := c.Ssids()
+		var out string
+		for _, ssid := range SSIDs {
+			out += strings.TrimSpace(ssid.Ssid) + ","
+		}
+		out = out[:len(out)-1]
+		err := ioutil.WriteFile(ssidsFile, []byte(out), 0644)
+		if err != nil {
+			fmt.Println("Error writing ssids to ", ssidsFile)
+		}
+	}
+	return
+}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	//"bufio"
-	//"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -12,34 +10,10 @@ import (
 	"github.com/CanonicalLtd/UCWifiConnect/netman"
 )
 
-/*
-type options struct {
-	devel bool
-}
-
-func args() *options {
-	opts := &options{}
-	flag.BoolVar(&opts.devel, "devel", false, "Test a hard coded devel path")
-	return opts
-}
-*/
 func main() {
 	c := netman.DefaultClient()
-	/*
-		opts := args()
-			if opts.devel {
-				dvs := c.GetDevices()
-				dwvs := c.GetWifiDevices(dvs)
-				for _, d := range dwvs {
-					fmt.Println(d)
-				}
-				return
-			}
-	*/
 	ssidsFile := os.Getenv("SNAP_COMMON") + "/ssids"
 	for {
-		fmt.Println("==== iter")
-		time.Sleep(200 * time.Millisecond)
 		SSIDs, _, _ := c.Ssids()
 		var out string
 		for _, ssid := range SSIDs {
@@ -50,6 +24,8 @@ func main() {
 		if err != nil {
 			fmt.Println("Error writing ssids to ", ssidsFile)
 		}
+		// wait 5 seconds
+		time.Sleep(5000 * time.Millisecond)
 	}
 	return
 }

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,6 +17,10 @@ apps:
   wifi-ap:
     command: wifi-ap
     plugs: [control, network]
+  daemon:
+    command: daemon
+    daemon: simple
+    plugs: [network-manager]
 
 plugs:
   control:


### PR DESCRIPTION
As a early prototype for the daemon, this commit runs a snap daemon that:
* every five seconds gets ssids (through netman pkg)
* if any are found, writes them to SNAP_COMMON/ssids as a comma delimited list: 
$ cat /var/snap/wifi-connect/common/ssids 
treetop_garden,anotherwifi,neighborwifi

That's ^ the *file* the http server should read to get ssids (because with wifi-ap UP the single wifi card is not managed by network-manager and thus we cannot read current ssids). The deamon will write the file before starting the server as we move along in devel.

You can verify the file stops changing after setting the wlan0 interface not managed:
$ nmcli d set wlan0 managed n

Then verify it starts changing again after setting it managed with:
wifi-connect.netman -manage-iface wlan0