### PR TITLE
Http server mgmt

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -1,1 +1,5 @@
 github.com/godbus/dbus	git	fe0e1d54eaeda11a9979659a8d32f459e88bee75	2017-03-03T19:03:06Z
+github.com/gorilla/context	git	08b5f424b9271eedf6f9f0ce86cb9396ed337a42	2016-08-17T18:46:32Z
+github.com/gorilla/mux	git	757bef944d0f21880861c2dd9c871ca543023cba	2016-09-20T23:08:13Z
+github.com/reiver/go-oi	git	431c83978379297f04f85f6eb94f129f25ab741d	2016-03-25T06:16:15Z
+github.com/reiver/go-telnet	git	6b696f32801a8f8dd07947f1e1fdb1a7dc4766ff	2016-03-30T05:09:16Z

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/csv"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -55,12 +56,20 @@ func execTemplate(w http.ResponseWriter, templatePath string, data Data) {
 func readSsidsFile() ([]string, error) {
 	f, err := os.Open(SsidsFile)
 	if err != nil {
+
+		//TODO TRACE
+		log.Printf("ERROR:%v", err)
+
 		return nil, err
 	}
 
 	reader := csv.NewReader(f)
 	// all ssids are in the same record
 	record, err := reader.Read()
+	if err == io.EOF {
+		empty := make([]string, 0)
+		return empty, nil
+	}
 	return record, err
 }
 

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -52,6 +52,10 @@ func execTemplate(w http.ResponseWriter, templatePath string, data Data) {
 func SsidsHandler(w http.ResponseWriter, r *http.Request) {
 	c := netman.DefaultClient()
 	// build dynamic data object
+	//FIXME: Instead of getting ssids directly using netman, we better read from $SNAP_COMMON/ssids file
+	// where daemon will put available ssids to connect to. Otherwise they could not be retrieved
+	// if in AP mode.
+	// NOTE: Ssids file is in CSV format. There is a specific golang csv package to manage it.
 	ssids, _, _ := c.Ssids()
 	data := SsidsData{Ssids: ssids}
 

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -27,7 +27,7 @@ type Data interface{}
 
 // SsidsData dynamic data to fulfill the SSIDs page template
 type SsidsData struct {
-	Ssids []netman.SSID
+	Ssids []string
 }
 
 // ConnectingData dynamic data to fulfill the connect result page template
@@ -66,19 +66,14 @@ func readSsidsFile() ([]string, error) {
 
 // SsidsHandler lists the current available SSIDs
 func SsidsHandler(w http.ResponseWriter, r *http.Request) {
-	c := netman.DefaultClient()
-	// build dynamic data object
-	//FIXME: Instead of getting ssids directly using netman, we better read from $SNAP_COMMON/ssids file
-	// where daemon will put available ssids to connect to. Otherwise they could not be retrieved
-	// if in AP mode.
-	// NOTE: Ssids file is in CSV format. There is a specific golang csv package to manage it.
-	_, err := readSsidsFile()
+	// daemon stores current available ssids in a file
+	ssids, err := readSsidsFile()
 	if err != nil {
 		log.Printf("Error reading SSIDs file: %v", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	ssids, _, _ := c.Ssids()
+
 	data := SsidsData{Ssids: ssids}
 
 	// parse template

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -1,0 +1,55 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestSsidsHandler(t *testing.T) {
+
+	ResourcesPath = "../static"
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("GET", "/", nil)
+	http.HandlerFunc(SsidsHandler).ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status %d, got: %d", http.StatusOK, w.Code)
+	}
+
+	if !strings.Contains(w.Header().Get("Content-Type"), "text/html") {
+		t.Error("Response content type is not expected text/html")
+	}
+}
+
+func TestConnectHandler(t *testing.T) {
+
+	ResourcesPath = "../static"
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("POST", "/connect", nil)
+	http.HandlerFunc(SsidsHandler).ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status %d, got: %d", http.StatusOK, w.Code)
+	}
+
+	if !strings.Contains(w.Header().Get("Content-Type"), "text/html") {
+		t.Error("Response content type is not expected text/html")
+	}
+}
+
+func TestInvalidTemplateHandler(t *testing.T) {
+
+	ResourcesPath = "/invalidpath"
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("GET", "/", nil)
+	http.HandlerFunc(SsidsHandler).ServeHTTP(w, r)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("Expected status %d, got: %d", http.StatusInternalServerError, w.Code)
+	}
+}

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -10,6 +10,7 @@ import (
 func TestSsidsHandler(t *testing.T) {
 
 	ResourcesPath = "../static"
+	SsidsFile = "../static/tests/ssids"
 
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest("GET", "/", nil)
@@ -51,5 +52,37 @@ func TestInvalidTemplateHandler(t *testing.T) {
 
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("Expected status %d, got: %d", http.StatusInternalServerError, w.Code)
+	}
+}
+
+func TestReadSsidsFile(t *testing.T) {
+
+	SsidsFile = "../static/tests/ssids"
+
+	ssids, err := readSsidsFile()
+	if err != nil {
+		t.Errorf("Unexpected error reading ssids file: %v", err)
+	}
+
+	if len(ssids) != 4 {
+		t.Error("Expected 4 elements in csv record")
+	}
+
+	set := make(map[string]bool)
+	for _, v := range ssids {
+		set[v] = true
+	}
+
+	if !set["mynetwork"] {
+		t.Error("mynetwork value not found")
+	}
+	if !set["yournetwork"] {
+		t.Error("yournetwork value not found")
+	}
+	if !set["hernetwork"] {
+		t.Error("hernetwork value not found")
+	}
+	if !set["hisnetwork"] {
+		t.Error("hisnetwork value not found")
 	}
 }

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -86,3 +86,40 @@ func TestReadSsidsFile(t *testing.T) {
 		t.Error("hisnetwork value not found")
 	}
 }
+
+func TestReadSsidsFileWithOnlyOne(t *testing.T) {
+
+	SsidsFile = "../static/tests/ssids_onlyonessid"
+
+	ssids, err := readSsidsFile()
+	if err != nil {
+		t.Errorf("Unexpected error reading ssids file: %v", err)
+	}
+
+	if len(ssids) != 1 {
+		t.Error("Expected 1 elements in csv record")
+	}
+
+	set := make(map[string]bool)
+	for _, v := range ssids {
+		set[v] = true
+	}
+
+	if !set["mynetwork"] {
+		t.Error("mynetwork value not found")
+	}
+}
+
+func TestReadEmptySsidsFile(t *testing.T) {
+
+	SsidsFile = "../static/tests/ssids_empty"
+
+	ssids, err := readSsidsFile()
+	if err != nil {
+		t.Errorf("Unexpected error reading ssids file: %v", err)
+	}
+
+	if len(ssids) != 0 {
+		t.Error("Expected 0 elements in csv record")
+	}
+}

--- a/server/launcher.go
+++ b/server/launcher.go
@@ -9,54 +9,6 @@ import (
 	"log"
 )
 
-const (
-	address = ":8080"
-)
-
-// ListenAndServe starts http server.
-
-// StartManagementServer starts web server for AP in management mode
-/* Howto start and stop server
-srvCLoser, err := server.StartManagementServer()
-if err != nil {
-	log.Fatalln("StartManagementServer Error - ", err)
-}
-
-// Do Stuff
-
-// Close HTTP Server
-err = srvCLoser.Close()
-if err != nil {
-	log.Fatalln("Server Close Error - ", err)
-}
-
-log.Println("Server Closed")
-*/
-func StartManagementServer() (sc io.Closer, err error) {
-	return listenAndServe(address, managementHandler())
-}
-
-// StartOperationalServer starts web server when connected to external WIFI
-/* Howto start and stop server
-srvCLoser, err := server.StartOperationalServer()
-if err != nil {
-	log.Fatalln("StartOperationalServer Error - ", err)
-}
-
-// Do Stuff
-
-// Close HTTP Server
-err = srvCLoser.Close()
-if err != nil {
-	log.Fatalln("Server Close Error - ", err)
-}
-
-log.Println("Server Closed")
-*/
-func StartOperationalServer() (sc io.Closer, err error) {
-	return listenAndServe(address, operationalHandler())
-}
-
 type tcpKeepAliveListener struct {
 	*net.TCPListener
 }

--- a/server/launcher.go
+++ b/server/launcher.go
@@ -36,11 +36,11 @@ func StartManagementServer() (sc io.Closer, err error) {
 	return listenAndServe(address, managementHandler())
 }
 
-// StartExternalServer starts web server when connected to external WIFI
+// StartOperationalServer starts web server when connected to external WIFI
 /* Howto start and stop server
-srvCLoser, err := server.StartExternalServer()
+srvCLoser, err := server.StartOperationalServer()
 if err != nil {
-	log.Fatalln("StartExternalServer Error - ", err)
+	log.Fatalln("StartOperationalServer Error - ", err)
 }
 
 // Do Stuff
@@ -53,15 +53,15 @@ if err != nil {
 
 log.Println("Server Closed")
 */
-func StartExternalServer() (sc io.Closer, err error) {
-	return listenAndServe(address, externalHandler())
+func StartOperationalServer() (sc io.Closer, err error) {
+	return listenAndServe(address, operationalHandler())
 }
 
 type tcpKeepAliveListener struct {
 	*net.TCPListener
 }
 
-// Accept accepts incomming tcp connections
+// Accept accepts incoming tcp connections
 func (ln tcpKeepAliveListener) Accept() (c net.Conn, err error) {
 	tc, err := ln.AcceptTCP()
 	if err != nil {

--- a/server/launcher.go
+++ b/server/launcher.go
@@ -1,0 +1,95 @@
+package server
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"time"
+
+	"log"
+)
+
+const (
+	address = ":8080"
+)
+
+// ListenAndServe starts http server.
+
+// StartManagementServer starts web server for AP in management mode
+/* Howto start and stop server
+srvCLoser, err := server.StartManagementServer()
+if err != nil {
+	log.Fatalln("StartManagementServer Error - ", err)
+}
+
+// Do Stuff
+
+// Close HTTP Server
+err = srvCLoser.Close()
+if err != nil {
+	log.Fatalln("Server Close Error - ", err)
+}
+
+log.Println("Server Closed")
+*/
+func StartManagementServer() (sc io.Closer, err error) {
+	return listenAndServe(address, managementHandler())
+}
+
+// StartExternalServer starts web server when connected to external WIFI
+/* Howto start and stop server
+srvCLoser, err := server.StartExternalServer()
+if err != nil {
+	log.Fatalln("StartExternalServer Error - ", err)
+}
+
+// Do Stuff
+
+// Close HTTP Server
+err = srvCLoser.Close()
+if err != nil {
+	log.Fatalln("Server Close Error - ", err)
+}
+
+log.Println("Server Closed")
+*/
+func StartExternalServer() (sc io.Closer, err error) {
+	return listenAndServe(address, externalHandler())
+}
+
+type tcpKeepAliveListener struct {
+	*net.TCPListener
+}
+
+// Accept accepts incomming tcp connections
+func (ln tcpKeepAliveListener) Accept() (c net.Conn, err error) {
+	tc, err := ln.AcceptTCP()
+	if err != nil {
+		return
+	}
+	tc.SetKeepAlive(true)
+	tc.SetKeepAlivePeriod(3 * time.Minute)
+	return tc, nil
+}
+
+func listenAndServe(addr string, handler http.Handler) (sc io.Closer, err error) {
+
+	var listener net.Listener
+
+	srv := &http.Server{Addr: addr, Handler: handler}
+
+	listener, err = net.Listen("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+
+	// launching server in a goroutine for not blocking
+	go func() {
+		err := srv.Serve(tcpKeepAliveListener{listener.(*net.TCPListener)})
+		if err != nil {
+			log.Println("HTTP Server Error - ", err)
+		}
+	}()
+
+	return listener, nil
+}

--- a/server/launcher_test.go
+++ b/server/launcher_test.go
@@ -1,0 +1,34 @@
+package server
+
+import (
+	"testing"
+
+	telnet "github.com/reiver/go-telnet"
+)
+
+func TestLaunchAndStop(t *testing.T) {
+
+	thePort := ":14444"
+
+	srv, err := listenAndServe(thePort, nil)
+	if err != nil {
+		t.Errorf("Start server failed: %v", err)
+	}
+
+	if srv == nil {
+		t.Error("Server could not be initialzed")
+	}
+
+	// telnet to check server is alive
+	caller := telnet.StandardCaller
+	err = telnet.DialToAndCall("localhost"+thePort, caller)
+	if err != nil {
+		t.Errorf("Failed to telnet localhost server at port %v: %v", thePort, err)
+	}
+
+	err = srv.Close()
+	if err != nil {
+		t.Errorf("Stop server error: %v", err)
+	}
+
+}

--- a/server/manager.go
+++ b/server/manager.go
@@ -1,0 +1,120 @@
+package server
+
+import (
+	"io"
+	"log"
+)
+
+const (
+	address = ":8080"
+)
+
+const (
+	// NONE any server is up
+	NONE RunningServer = 0 + iota
+	// MANAGEMENT only management portal is up. Rest are down
+	MANAGEMENT
+	// OPERATIONAL only operational portal is up. Rest are down
+	OPERATIONAL
+)
+
+// RunningServer enum defining which server is up and running
+type RunningServer int
+
+var currentlyRunning = NONE
+var managementCloser io.Closer
+var operationalCloser io.Closer
+
+// Running returns RunningServer enum value saying which server is running
+func Running() RunningServer {
+	return currentlyRunning
+}
+
+// StartManagementServer starts server in management mode
+func StartManagementServer() error {
+	var err error
+	managementCloser, err = listenAndServe(address, managementHandler())
+	if err != nil {
+		managementCloser = nil
+		return err
+	}
+	return nil
+}
+
+// StartOperationalServer starts server in operational mode
+func StartOperationalServer() error {
+	var err error
+	operationalCloser, err = listenAndServe(address, operationalHandler())
+	if err != nil {
+		operationalCloser = nil
+		return err
+	}
+	return nil
+}
+
+// ShutdownManagementServer shutdown server management mode. If server is in operational mode, it does nothing
+func ShutdownManagementServer() error {
+	if managementCloser == nil {
+		log.Print("Skipping stop management server since it is not up")
+		return nil
+	}
+
+	err := managementCloser.Close()
+	managementCloser = nil
+	return err
+}
+
+// ShutdownOperationalServer shutdown server operational mode. If server is up in management mode, it does nothing
+func ShutdownOperationalServer() error {
+	if operationalCloser == nil {
+		log.Print("Skipping stop operational server since it is not up")
+		return nil
+	}
+
+	err := operationalCloser.Close()
+	operationalCloser = nil
+	return err
+}
+
+// ShutdownServer shutdown server no matter the mode it is up
+func ShutdownServer() error {
+	err := ShutdownManagementServer()
+	err2 := ShutdownOperationalServer()
+	if err != nil {
+		return err
+	}
+	if err2 != nil {
+		return err2
+	}
+	return nil
+}
+
+// SwitchToOperationalServer shutdowns management server if up and start operational one
+func SwitchToOperationalServer() error {
+	if Running() == OPERATIONAL {
+		log.Println("Server already in operational mode. Skipping")
+		return nil
+	}
+
+	err := ShutdownManagementServer()
+	if err != nil {
+		return err
+	}
+
+	return StartOperationalServer()
+}
+
+// SwitchToManagementServer shutdowns operational server if up and start management one
+func SwitchToManagementServer() error {
+	if Running() == MANAGEMENT {
+		log.Println("Server already in management mode. Skipping")
+		return nil
+	}
+
+	err := ShutdownOperationalServer()
+	if err != nil {
+		return err
+	}
+
+	return StartManagementServer()
+}

--- a/server/manager.go
+++ b/server/manager.go
@@ -16,8 +16,6 @@ const (
 	MANAGEMENT
 	// OPERATIONAL only operational portal is up. Rest are down
 	OPERATIONAL
-	// ALL operational and management portals are both up.
-	ALL
 )
 
 // RunningServer enum defining which server is up and running
@@ -40,6 +38,7 @@ func StartManagementServer() error {
 		managementCloser = nil
 		return err
 	}
+	currentlyRunning = MANAGEMENT
 	return nil
 }
 
@@ -51,6 +50,7 @@ func StartOperationalServer() error {
 		operationalCloser = nil
 		return err
 	}
+	currentlyRunning = OPERATIONAL
 	return nil
 }
 
@@ -62,8 +62,15 @@ func ShutdownManagementServer() error {
 	}
 
 	err := managementCloser.Close()
+	if err != nil {
+		return err
+	}
 	managementCloser = nil
-	return err
+	// TODO for now we only have one server up at a time. Later, if happens
+	// that more than one can be up at the same time it would be needed manage this
+	// state changes in a better way
+	currentlyRunning = NONE
+	return nil
 }
 
 // ShutdownOperationalServer shutdown server operational mode. If server is up in management mode, it does nothing
@@ -74,8 +81,15 @@ func ShutdownOperationalServer() error {
 	}
 
 	err := operationalCloser.Close()
+	if err != nil {
+		return err
+	}
 	operationalCloser = nil
-	return err
+	// TODO for now we only have one server up at a time. Later, if happens
+	// that more than one can be up at the same time it would be needed manage this
+	// state changes in a better way
+	currentlyRunning = NONE
+	return nil
 }
 
 // ShutdownServer shutdown server no matter the mode it is up
@@ -88,5 +102,6 @@ func ShutdownServer() error {
 	if err2 != nil {
 		return err2
 	}
+	currentlyRunning = NONE
 	return nil
 }

--- a/server/manager.go
+++ b/server/manager.go
@@ -16,6 +16,8 @@ const (
 	MANAGEMENT
 	// OPERATIONAL only operational portal is up. Rest are down
 	OPERATIONAL
+	// ALL operational and management portals are both up.
+	ALL
 )
 
 // RunningServer enum defining which server is up and running
@@ -87,34 +89,4 @@ func ShutdownServer() error {
 		return err2
 	}
 	return nil
-}
-
-// SwitchToOperationalServer shutdowns management server if up and start operational one
-func SwitchToOperationalServer() error {
-	if Running() == OPERATIONAL {
-		log.Println("Server already in operational mode. Skipping")
-		return nil
-	}
-
-	err := ShutdownManagementServer()
-	if err != nil {
-		return err
-	}
-
-	return StartOperationalServer()
-}
-
-// SwitchToManagementServer shutdowns operational server if up and start management one
-func SwitchToManagementServer() error {
-	if Running() == MANAGEMENT {
-		log.Println("Server already in management mode. Skipping")
-		return nil
-	}
-
-	err := ShutdownOperationalServer()
-	if err != nil {
-		return err
-	}
-
-	return StartManagementServer()
 }

--- a/server/router.go
+++ b/server/router.go
@@ -21,8 +21,8 @@ func managementHandler() *mux.Router {
 	return router
 }
 
-// externalHandler handles request for web UI when connected to external WIFI
-func externalHandler() *mux.Router {
+// operationalHandler handles request for web UI when connected to external WIFI
+func operationalHandler() *mux.Router {
 
 	//TODO IMPLEMENT
 	return nil

--- a/server/router.go
+++ b/server/router.go
@@ -1,0 +1,29 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+// managementHandler handles requests for web UI when AP is up
+func managementHandler() *mux.Router {
+	router := mux.NewRouter()
+
+	// Pages routes
+	router.HandleFunc("/", SsidsHandler).Methods("GET")
+	router.HandleFunc("/connect", ConnectHandler).Methods("POST")
+
+	// Resources path
+	fs := http.StripPrefix("/static/", http.FileServer(http.Dir(ResourcesPath)))
+	router.PathPrefix("/static/").Handler(fs)
+
+	return router
+}
+
+// externalHandler handles request for web UI when connected to external WIFI
+func externalHandler() *mux.Router {
+
+	//TODO IMPLEMENT
+	return nil
+}

--- a/static/templates/ssids.html
+++ b/static/templates/ssids.html
@@ -21,13 +21,13 @@
                 {{range $i, $ssid := .Ssids}}
                 <tr>
                     <th scope="row">
-                        <label class="collapse" for="radio{{$i}}">{{$ssid.Ssid}}</label>
+                        <label class="collapse" for="radio{{$i}}">{{$ssid}}</label>
                         <input id="radio{{$i}}" type="radio" name="c1">
                         <div class="six-col">
                         <fieldset>
                         <ul class="no-bullets">
                             <li>
-                                <input type="hidden" id="ssid{{$i}}" value="{{$ssid.Ssid}}"/>
+                                <input type="hidden" id="ssid{{$i}}" value="{{$ssid}}"/>
                                 <label for="passphrase">Enter passphrase:</label>
                                 <input type="password" id="passphrase{{$i}}"/>
                             </li>

--- a/static/tests/ssids
+++ b/static/tests/ssids
@@ -1,0 +1,1 @@
+mynetwork,yournetwork,hernetwork,hisnetwork

--- a/static/tests/ssids_onlyonessid
+++ b/static/tests/ssids_onlyonessid
@@ -1,0 +1,1 @@
+mynetwork


### PR DESCRIPTION
- Moved http server management to functions
- There is a specific function for starting server with certain handler that will manage ssids list or operational portal. Depending on which one used to start the server will start up one or the other (server.StartManagementServer() or server.StartExternalServer())
- Those methods will return a io.Closer. Calling its Close() method will shutdown server
- Reading ssids from the file in the snap common folder
- Added tests for http handlers
- Added a not unitary test which starts the server and verifies it is up by telnet 