### PR TITLE
Replace sleeps

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -99,9 +99,9 @@ func checkWaitApConnect() bool {
 }
 
 // if wifiap is UP and there are no known SSIDs, bring it down so on next
-// loop iter we start again and can get SSIDs. returns true when ip is 
+// loop iter we start again and can get SSIDs. returns true when ip is
 // UP and has no ssids
-func isApUpWithoutSSIDs(cw * wifiap.Client) bool {
+func isApUpWithoutSSIDs(cw *wifiap.Client) bool {
 	wifiUp, _ := cw.Enabled()
 	if !wifiUp {
 		return false
@@ -112,7 +112,7 @@ func isApUpWithoutSSIDs(cw * wifiap.Client) bool {
 		return true // ap is up with no ssids
 	}
 	return false
-} 
+}
 
 // managementServerUp starts the management server if it is
 // not running

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -54,7 +54,6 @@ func setState(s int) {
 // to path and return true, else return false.
 func scanSsids(path string, c *netman.Client) bool {
 	manage(c)
-	time.Sleep(5000 * time.Millisecond)
 	SSIDs, _, _ := c.Ssids()
 	//only write SSIDs when found
 	if len(SSIDs) > 0 {
@@ -67,7 +66,7 @@ func scanSsids(path string, c *netman.Client) bool {
 		if err != nil {
 			fmt.Println("== wifi-connect: Error writing SSID(s) to ", path)
 		} else {
-			fmt.Println("== wifi-connect: SSID(s) found and written to ", path)
+			fmt.Println("== wifi-connect: SSID(s) obtained")
 			return true
 		}
 	}
@@ -98,6 +97,22 @@ func checkWaitApConnect() bool {
 	}
 	return true
 }
+
+// if wifiap is UP and there are no known SSIDs, bring it down so on next
+// loop iter we start again and can get SSIDs. returns true when ip is 
+// UP and has no ssids
+func isApUpWithoutSSIDs(cw * wifiap.Client) bool {
+	wifiUp, _ := cw.Enabled()
+	if !wifiUp {
+		return false
+	}
+	ssids, _ := utils.ReadSsidsFile()
+	if len(ssids) < 1 {
+		fmt.Println("== wifi-connect: wifi-ap is UP but has no SSIDS")
+		return true // ap is up with no ssids
+	}
+	return false
+} 
 
 // managementServerUp starts the management server if it is
 // not running
@@ -152,23 +167,23 @@ func main() {
 	first := true
 	c := netman.DefaultClient()
 	cw := wifiap.DefaultClient()
-	ssidsPath := os.Getenv("SNAP_COMMON") + "/ssids"
 
 	// stop servers if running at start
 	managementServerDown()
-	operationalServerDown()
+	//operationalServerDown()
 
 	//remove possibly left over wait flag file
 	utils.RemoveWaitFile()
 
 	for {
 		if first {
-			fmt.Println("== wifi-connect: daemon starting ==")
+			fmt.Println("== wifi-connect: daemon STARTING")
+			previousState = STARTING
+			state = STARTING
 			first = false
-			//first boot sometimes needs more time
-			time.Sleep(40000 * time.Millisecond)
 			//clean start require wifi AP down so we can get SSIDs
 			cw.Disable()
+			//TODO only wait if wlan0 is managed
 			//wait time period (TBD) on first run to allow wifi connections
 			time.Sleep(40000 * time.Millisecond)
 			//remove previous state flag, if any on deamon startup
@@ -177,6 +192,12 @@ func main() {
 
 		// wait 5 seconds on each iter
 		time.Sleep(5000 * time.Millisecond)
+
+		// the AP should not be up without SSIDS
+		if isApUpWithoutSSIDs(cw) {
+			cw.Disable()
+			continue
+		}
 
 		// wait/loop until management portal's wait flag file is gone
 		// this stops daemon state changing until the management portal
@@ -191,7 +212,7 @@ func main() {
 		if c.ConnectedWifi(c.GetWifiDevices(c.GetDevices())) {
 			setState(OPERATING)
 			if previousState != OPERATING {
-				fmt.Println("== wifi-connect: entering operational mode ==")
+				fmt.Println("== wifi-connect: entering OPERATIONAL mode")
 			}
 			if previousState == MANAGING {
 				managementServerDown()
@@ -201,9 +222,9 @@ func main() {
 			continue
 		}
 
-		state = MANAGING
+		setState(MANAGING)
 		if previousState != MANAGING {
-			fmt.Println("== wifi-connect: entering management mode ==")
+			fmt.Println("== wifi-connect: entering MANAGEMENT mode")
 		}
 
 		// if wlan0 managed, set unmanaged so that we can bring up wifi-ap
@@ -223,13 +244,13 @@ func main() {
 
 		//get ssids if wifi-ap Down
 		if !wifiUp {
-			found := scanSsids(ssidsPath, c)
+			found := scanSsids(utils.SsidsFile, c)
 			unmanage(c)
 			if !found {
-				fmt.Println("== wifi-connect: No SSIDs found. Looping.")
+				fmt.Println("== wifi-connect: Looping.")
 				continue
 			}
-			fmt.Println("== wifi-connect: Have SSIDs: start wifi-ap")
+			fmt.Println("== wifi-connect: start wifi-ap")
 			cw.Enable()
 			managementServerUp()
 		}

--- a/netman/dbus.go
+++ b/netman/dbus.go
@@ -201,7 +201,7 @@ func (c *Client) ConnectAp(ssid string, p string, ap2device map[string]string, s
 	trying := true
 	idx := -1
 	for trying {
-		idx += 1
+		idx++
 		time.Sleep(1000 * time.Millisecond)
 		if c.Connected(c.GetWifiDevices(c.GetDevices())) {
 			return
@@ -324,7 +324,7 @@ func (c *Client) SetIfaceManaged(iface string, state bool, devices []string) str
 		// loop until interface is in desired managed state or max iters reached
 		idx := -1
 		for {
-			idx += 1
+			idx++
 			time.Sleep(1000 * time.Millisecond)
 			managedState, err := c.dbusClient.BusObj.GetProperty("org.freedesktop.NetworkManager.Device.State")
 			if err == nil {

--- a/netman/dbus.go
+++ b/netman/dbus.go
@@ -206,6 +206,9 @@ func (c *Client) ConnectAp(ssid string, p string, ap2device map[string]string, s
 		if c.Connected(c.GetWifiDevices(c.GetDevices())) {
 			return
 		}
+		if idx == 19 {
+			fmt.Println("== wifi-connect: cannot connect to AP")
+		}
 	}
 }
 

--- a/netman/dbus.go
+++ b/netman/dbus.go
@@ -197,7 +197,7 @@ func (c *Client) ConnectAp(ssid string, p string, ap2device map[string]string, s
 	setObject(c, "org.freedesktop.NetworkManager", dbus.ObjectPath("/org/freedesktop/NetworkManager"))
 	c.dbusClient.BusObj.Call("org.freedesktop.NetworkManager.AddAndActivateConnection", 0, outer, dbus.ObjectPath(ap2device[ssid2ap[ssid]]), dbus.ObjectPath(ssid2ap[ssid]))
 
-	// loop until connected or until max loops 
+	// loop until connected or until max loops
 	trying := true
 	idx := -1
 	for trying {
@@ -245,6 +245,7 @@ func (c *Client) Connected(devices []string) bool {
 			fmt.Println("== wifi-connect: Error getting device state:", err2)
 			continue
 		}
+		// only handle eth and wifi device type
 		if dbus.Variant.Value(dType) != uint32(1) && dbus.Variant.Value(dType) != uint32(2) {
 			continue
 		}
@@ -325,7 +326,7 @@ func (c *Client) SetIfaceManaged(iface string, state bool, devices []string) str
 			managedState, err := c.dbusClient.BusObj.GetProperty("org.freedesktop.NetworkManager.Device.State")
 			if err == nil {
 				switch state {
-				case true: 
+				case true:
 					if managedState.Value() == uint32(30) { //NM_DEVICE_STATE_DISCONNECTED
 						return iface
 					}
@@ -335,12 +336,12 @@ func (c *Client) SetIfaceManaged(iface string, state bool, devices []string) str
 					}
 				}
 			}
-			if idx == 59 {//give it 60 iters ~= one minute
+			if idx == 59 { //give it 60 iters ~= one minute
 				break
 			}
 		}
 	}
-	return  "" //no iface state changed
+	return "" //no iface state changed
 }
 
 // WifisManaged returns  map[iface]device of wifi iterfaces that are managed by network manager

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -22,12 +22,15 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/CanonicalLtd/UCWifiConnect/utils"
 )
 
 func TestSsidsHandler(t *testing.T) {
 
 	ResourcesPath = "../static"
-	SsidsFile = "../static/tests/ssids"
+	SsidsFile := "../static/tests/ssids"
+	utils.SetSsidsFile(SsidsFile)
 
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest("GET", "/", nil)
@@ -74,9 +77,9 @@ func TestInvalidTemplateHandler(t *testing.T) {
 
 func TestReadSsidsFile(t *testing.T) {
 
-	SsidsFile = "../static/tests/ssids"
-
-	ssids, err := readSsidsFile()
+	SsidsFile := "../static/tests/ssids"
+	utils.SetSsidsFile(SsidsFile)
+	ssids, err := utils.ReadSsidsFile()
 	if err != nil {
 		t.Errorf("Unexpected error reading ssids file: %v", err)
 	}
@@ -106,9 +109,9 @@ func TestReadSsidsFile(t *testing.T) {
 
 func TestReadSsidsFileWithOnlyOne(t *testing.T) {
 
-	SsidsFile = "../static/tests/ssids_onlyonessid"
-
-	ssids, err := readSsidsFile()
+	SsidsFile := "../static/tests/ssids_onlyonessid"
+	utils.SetSsidsFile(SsidsFile)
+	ssids, err := utils.ReadSsidsFile()
 	if err != nil {
 		t.Errorf("Unexpected error reading ssids file: %v", err)
 	}
@@ -129,9 +132,9 @@ func TestReadSsidsFileWithOnlyOne(t *testing.T) {
 
 func TestReadEmptySsidsFile(t *testing.T) {
 
-	SsidsFile = "../static/tests/ssids_empty"
-
-	ssids, err := readSsidsFile()
+	SsidsFile := "../static/tests/ssids_empty"
+	utils.SetSsidsFile(SsidsFile)
+	ssids, err := utils.ReadSsidsFile()
 	if err != nil {
 		t.Errorf("Unexpected error reading ssids file: %v", err)
 	}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: wifi-connect 
-version: '0.7'
+version: '0.8'
 summary: Connect your device to external wifi over temp wifi AP
 description: |
     A solution to enable your device to connect to ian external

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -31,7 +31,7 @@ import (
 // SsidsFile path to the file filled by daemon with available ssids in csv format
 var SsidsFile = filepath.Join(os.Getenv("SNAP_COMMON"), "ssids")
 
-// Set the SsidsFile var
+// SetSsidsFile sets the SsidsFile var
 func SetSsidsFile(p string) {
 	SsidsFile = p
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -31,6 +31,10 @@ import (
 // SsidsFile path to the file filled by daemon with available ssids in csv format
 var SsidsFile = filepath.Join(os.Getenv("SNAP_COMMON"), "ssids")
 
+func SetSsidsFile(p string) {
+	SsidsFile = p
+}
+
 // PrintMapSorted prints to stdout a map sorting content by keys
 func PrintMapSorted(m map[string]interface{}) {
 	sortedKeys := make([]string, 0, len(m))
@@ -89,5 +93,3 @@ func ReadSsidsFile() ([]string, error) {
 	}
 	return record, err
 }
-
-

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -31,6 +31,7 @@ import (
 // SsidsFile path to the file filled by daemon with available ssids in csv format
 var SsidsFile = filepath.Join(os.Getenv("SNAP_COMMON"), "ssids")
 
+// Set the SsidsFile var
 func SetSsidsFile(p string) {
 	SsidsFile = p
 }
@@ -64,7 +65,7 @@ func RemoveWaitFile() {
 		//loop up to 10 times to try again if tmp file lock prevents delete
 		idx := -1
 		for {
-			idx += 1
+			idx++
 			err := os.Remove(waitApPath)
 			if err == nil {
 				return
@@ -77,7 +78,7 @@ func RemoveWaitFile() {
 	}
 }
 
-// read the ssids file, if any
+// ReadSsidsFile read the ssids file, if any
 func ReadSsidsFile() ([]string, error) {
 	f, err := os.Open(SsidsFile)
 	if err != nil {

--- a/wifiap/wifiap.go
+++ b/wifiap/wifiap.go
@@ -88,7 +88,7 @@ func (client *Client) Enable() error {
 	idx := -1
 	for trying {
 		time.Sleep(1000 * time.Millisecond)
-		idx += 1
+		idx++
 		response, err := client.restClient.sendHTTPRequest("http://unix/v1/status", "GET", nil)
 		if err != nil {
 			return err
@@ -126,7 +126,7 @@ func (client *Client) Disable() error {
 	idx := -1
 	for trying {
 		time.Sleep(1000 * time.Millisecond)
-		idx += 1
+		idx++
 		response, err := client.restClient.sendHTTPRequest("http://unix/v1/status", "GET", nil)
 		if err != nil {
 			return err

--- a/wifiap/wifiap.go
+++ b/wifiap/wifiap.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/http"
 	"path/filepath"
+	"time"
 )
 
 // Client struct exposing wifi-ap operations
@@ -82,6 +83,24 @@ func (client *Client) Enable() error {
 		return fmt.Errorf("Failed to set configuration, service returned: %d (%s)", response.StatusCode, response.Status)
 	}
 
+	// loop until wifi-ap is up or limit reached
+	trying := true
+	idx := -1
+	for trying {
+		time.Sleep(1000 * time.Millisecond)
+		idx += 1
+		response, err := client.restClient.sendHTTPRequest("http://unix/v1/status", "GET", nil)
+		if err != nil {
+			return err
+		}
+		if response.Result["ap.active"] == true {
+			return nil
+		}
+		if idx == 29 {
+			trying = false
+		}
+	}
+
 	return nil
 }
 
@@ -102,6 +121,23 @@ func (client *Client) Disable() error {
 		return fmt.Errorf("Failed to set configuration, service returned: %d (%s)", response.StatusCode, response.Status)
 	}
 
+	// loop until wifi-ap is down or limit reached
+	trying := true
+	idx := -1
+	for trying {
+		time.Sleep(1000 * time.Millisecond)
+		idx += 1
+		response, err := client.restClient.sendHTTPRequest("http://unix/v1/status", "GET", nil)
+		if err != nil {
+			return err
+		}
+		if response.Result["ap.active"] == false {
+			return nil
+		}
+		if idx == 29 {
+			trying = false
+		}
+	}
 	return nil
 }
 

--- a/wifiap/wifiap_test.go
+++ b/wifiap/wifiap_test.go
@@ -174,28 +174,46 @@ type mockTransportEnable struct{}
 func (mock *mockTransportEnable) Do(req *http.Request) (*http.Response, error) {
 
 	url := req.URL.String()
-	if url != "http://unix/v1/configuration" {
+
+	switch url {
+	case "http://unix/v1/configuration":
+		if req.Method != "POST" {
+			return nil, fmt.Errorf("Method is not valid. Expected POST, got %v", req.Method)
+		}
+
+		err := validateHeaders(map[string]string{"disabled": "false"}, req)
+		if err != nil {
+			return nil, err
+		}
+
+		rawBody := `{"result":{},"status":"OK","status-code":200,"type":"sync"}`
+
+		response := http.Response{
+			StatusCode: 200,
+			Status:     "200 OK",
+			Body:       ioutil.NopCloser(strings.NewReader(rawBody)),
+		}
+
+		return &response, nil
+
+	case "http://unix/v1/status":
+		if req.Method != "GET" {
+			return nil, fmt.Errorf("Method is not valid. Expected GET, got %v", req.Method)
+		}
+
+		rawBody := `{"result":{"ap.active": true},"status":"OK","status-code":200,"type":"sync"}`
+
+		response := http.Response{
+			StatusCode: 200,
+			Status:     "200 OK",
+			Body:       ioutil.NopCloser(strings.NewReader(rawBody)),
+		}
+
+		return &response, nil
+
+	default:
 		return nil, fmt.Errorf("Not valid request URL: %v", url)
 	}
-
-	if req.Method != "POST" {
-		return nil, fmt.Errorf("Method is not valid. Expected POST, got %v", req.Method)
-	}
-
-	err := validateHeaders(map[string]string{"disabled": "false"}, req)
-	if err != nil {
-		return nil, err
-	}
-
-	rawBody := `{"result":{},"status":"OK","status-code":200,"type":"sync"}`
-
-	response := http.Response{
-		StatusCode: 200,
-		Status:     "200 OK",
-		Body:       ioutil.NopCloser(strings.NewReader(rawBody)),
-	}
-
-	return &response, nil
 }
 
 func TestEnable(t *testing.T) {
@@ -212,28 +230,48 @@ type mockTransportDisable struct{}
 func (mock *mockTransportDisable) Do(req *http.Request) (*http.Response, error) {
 
 	url := req.URL.String()
-	if url != "http://unix/v1/configuration" {
+
+	switch url {
+	case "http://unix/v1/configuration":
+
+		if req.Method != "POST" {
+			return nil, fmt.Errorf("Method is not valid. Expected POST, got %v", req.Method)
+		}
+
+		err := validateHeaders(map[string]string{"disabled": "true"}, req)
+		if err != nil {
+			return nil, err
+		}
+
+		rawBody := `{"result":{},"status":"OK","status-code":200,"type":"sync"}`
+
+		response := http.Response{
+			StatusCode: 200,
+			Status:     "200 OK",
+			Body:       ioutil.NopCloser(strings.NewReader(rawBody)),
+		}
+
+		return &response, nil
+
+	case "http://unix/v1/status":
+
+		if req.Method != "GET" {
+			return nil, fmt.Errorf("Method is not valid. Expected GET, got %v", req.Method)
+		}
+
+		rawBody := `{"result":{"ap.active": false},"status":"OK","status-code":200,"type":"sync"}`
+
+		response := http.Response{
+			StatusCode: 200,
+			Status:     "200 OK",
+			Body:       ioutil.NopCloser(strings.NewReader(rawBody)),
+		}
+
+		return &response, nil
+
+	default:
 		return nil, fmt.Errorf("Not valid request URL: %v", url)
 	}
-
-	if req.Method != "POST" {
-		return nil, fmt.Errorf("Method is not valid. Expected POST, got %v", req.Method)
-	}
-
-	err := validateHeaders(map[string]string{"disabled": "true"}, req)
-	if err != nil {
-		return nil, err
-	}
-
-	rawBody := `{"result":{},"status":"OK","status-code":200,"type":"sync"}`
-
-	response := http.Response{
-		StatusCode: 200,
-		Status:     "200 OK",
-		Body:       ioutil.NopCloser(strings.NewReader(rawBody)),
-	}
-
-	return &response, nil
 }
 
 func TestDisable(t *testing.T) {


### PR DESCRIPTION
All time.Sleeps() (except those that are valid to, for example, delay loop iterations) are removed [1]. 
Instead, functions block until the external expected condition has been achieved (or a max number of iterations has been reached). Increased reliability and responsiveness. 

[1] The 40 sec sleep in the first loop of the daemon remains.TBD investigate only sleeping here if wlan0 is managed by network manager to allow time for connections to establish. If not, we should continue directly with entering Management Mode.