### PR TITLE
Server status

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -138,27 +138,27 @@ func isApUpWithoutSSIDs(cw *wifiap.Client) bool {
 // managementServerUp starts the management server if it is
 // not running
 func managementServerUp() {
-	//if server.Running() != server.MANAGEMENT {
-	err = server.StartManagementServer()
-	if err != nil {
-		fmt.Println("== wifi-connect: Error start Mamagement portal:", err)
+	if server.Current != server.Management && server.State == server.Stopped {
+		err = server.StartManagementServer()
+		if err != nil {
+			fmt.Println("== wifi-connect: Error start Mamagement portal:", err)
+		}
+		// init mDNS
+		avahi.InitMDNS()
 	}
-	// init mDNS
-	avahi.InitMDNS()
-	//}
 }
 
 // managementServerDown stops the management server if it is running
 // also remove the wait flag file, thus resetting proper state
 func managementServerDown() {
-	//if server.Running() == server.MANAGEMENT {
-	err = server.ShutdownManagementServer()
-	if err != nil {
-		fmt.Println("== wifi-connect: Error stopping the Management portal:", err)
+	if server.Current == server.Management && (server.State == server.Running || server.State == server.Starting) {
+		err = server.ShutdownManagementServer()
+		if err != nil {
+			fmt.Println("== wifi-connect: Error stopping the Management portal:", err)
+		}
+		//remove flag fie so daemon resumes normal control
+		utils.RemoveFlagFile(os.Getenv("SNAP_COMMON") + "/startingApConnect")
 	}
-	//remove flag fie so daemon resumes normal control
-	utils.RemoveFlagFile(os.Getenv("SNAP_COMMON") + "/startingApConnect")
-	//}
 }
 
 // operationalServerUp starts the operational server if it is

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -164,7 +164,7 @@ func managementServerDown() {
 // operationalServerUp starts the operational server if it is
 // not running
 func operationalServerUp() {
-	if server.Running() != server.OPERATIONAL {
+	if server.Running() != server.Operational {
 		err = server.StartOperationalServer()
 		if err != nil {
 			fmt.Println("== wifi-connect: Error starting the Operational portal:", err)
@@ -176,7 +176,7 @@ func operationalServerUp() {
 
 // operationalServerdown stops the operational server if it is running
 func operationalServerDown() {
-	if server.Running() == server.OPERATIONAL {
+	if server.Running() == server.Operational {
 		err = server.ShutdownOperationalServer()
 		if err != nil {
 			fmt.Println("== wifi-connect: Error stopping Operational portal:", err)

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -164,7 +164,7 @@ func managementServerDown() {
 // operationalServerUp starts the operational server if it is
 // not running
 func operationalServerUp() {
-	if server.Running() != server.Operational {
+	if server.Current != server.Operational && server.State == server.Stopped {
 		err = server.StartOperationalServer()
 		if err != nil {
 			fmt.Println("== wifi-connect: Error starting the Operational portal:", err)
@@ -176,7 +176,7 @@ func operationalServerUp() {
 
 // operationalServerdown stops the operational server if it is running
 func operationalServerDown() {
-	if server.Running() == server.Operational {
+	if server.Current == server.Operational && (server.State == server.Running || server.State == server.Starting) {
 		err = server.ShutdownOperationalServer()
 		if err != nil {
 			fmt.Println("== wifi-connect: Error stopping Operational portal:", err)

--- a/server/fmt.go
+++ b/server/fmt.go
@@ -1,0 +1,16 @@
+package server
+
+import (
+	"github.com/CanonicalLtd/UCWifiConnect/utils"
+)
+
+// Errorf returns a new instance implementing error interface taken a formatted string and
+// params as input
+func Errorf(format string, a ...interface{}) error {
+	return utils.PkgErrorf("server", format, a...)
+}
+
+// Sprintf returns a formatted string with project prefix
+func Sprintf(format string, a ...interface{}) string {
+	return utils.PkgSprintf("server", format, a...)
+}

--- a/server/fmt_test.go
+++ b/server/fmt_test.go
@@ -1,0 +1,58 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/CanonicalLtd/UCWifiConnect/utils"
+)
+
+const (
+	pkg = "server"
+)
+
+func TestErrorFormat(t *testing.T) {
+
+	msg := "Whatever message"
+	e := Errorf(msg)
+	expected := utils.FmtPrefix + "/" + pkg + ": " + msg
+
+	if e.Error() != expected {
+		t.Errorf("Error is not well formatted, expected %v but got %v", expected, e.Error())
+	}
+}
+func TestErrorfFormat(t *testing.T) {
+
+	format := "Whatever %v"
+	detail := "message"
+	e := Errorf(format, detail)
+
+	expected := utils.FmtPrefix + "/" + pkg + ": Whatever message"
+
+	if e.Error() != expected {
+		t.Errorf("Error is not well formatted, expected %s but got %s", expected, e.Error())
+	}
+}
+
+func TestSprintFormat(t *testing.T) {
+
+	msg := "Whatever message"
+	e := Sprintf(msg)
+	expected := utils.FmtPrefix + "/" + pkg + ": " + msg
+
+	if e != expected {
+		t.Errorf("String is not well formatted, expected %s but got %s", expected, e)
+	}
+}
+
+func TestSprintfFormat(t *testing.T) {
+
+	format := "Whatever %v"
+	detail := "message"
+	e := Sprintf(format, detail)
+
+	expected := utils.FmtPrefix + "/" + pkg + ": Whatever message"
+
+	if e != expected {
+		t.Errorf("String is not well formatted, expected %s but got %s", expected, e)
+	}
+}

--- a/server/launcher.go
+++ b/server/launcher.go
@@ -56,7 +56,7 @@ func listenAndServe(addr string, handler http.Handler) (sc io.Closer, err error)
 	go func() {
 		err := srv.Serve(tcpKeepAliveListener{listener.(*net.TCPListener)})
 		if err != nil {
-			log.Println("HTTP Server Error - ", err)
+			log.Printf("HTTP Server closing - %v", err)
 		}
 	}()
 

--- a/server/launcher.go
+++ b/server/launcher.go
@@ -18,14 +18,12 @@
 package server
 
 import (
+	"log"
 	"net"
 	"net/http"
 	"time"
 
 	"github.com/CanonicalLtd/UCWifiConnect/utils"
-
-	"fmt"
-	"log"
 )
 
 const (
@@ -53,7 +51,7 @@ type tcpKeepAliveListener struct {
 	*net.TCPListener
 }
 
-// WaitForState waits for server reach certaing state
+// WaitForState waits for server reach certain state
 func WaitForState(state RunningState) bool {
 	retries := 10
 	idle := 10 * time.Millisecond
@@ -78,11 +76,11 @@ func (ln tcpKeepAliveListener) Accept() (net.Conn, error) {
 func listenAndServe(addr string, handler http.Handler) error {
 
 	if State != Stopped {
-		return fmt.Errorf("Server is not in proper stopped state before trying to start it")
+		return Errorf("Server is not in proper stopped state before trying to start it")
 	}
 
 	if utils.RunningOn(addr) {
-		return fmt.Errorf("Another instance is running in same address %v", addr)
+		return Errorf("Another instance is running in same address %v", addr)
 	}
 
 	State = Starting
@@ -108,7 +106,7 @@ func listenAndServe(addr string, handler http.Handler) error {
 		}
 
 		if retries == 0 {
-			log.Print("Server could not be started")
+			log.Print(Sprintf("Server could not be started"))
 			return
 		}
 
@@ -120,7 +118,7 @@ func listenAndServe(addr string, handler http.Handler) error {
 		if listener != nil {
 			err := srv.Serve(tcpKeepAliveListener{listener.(*net.TCPListener)})
 			if err != nil {
-				log.Printf("HTTP Server closing - %v", err)
+				log.Printf(Sprintf("HTTP Server closing - %v", err))
 			}
 			// notify server real stop
 			done <- true
@@ -135,12 +133,12 @@ func listenAndServe(addr string, handler http.Handler) error {
 func stop() error {
 
 	if State == Stopped {
-		return fmt.Errorf("Already stopped")
+		return Errorf("Already stopped")
 	}
 
 	if listener == nil {
 		State = Stopped
-		return fmt.Errorf("Already closed")
+		return Errorf("Already closed")
 	}
 
 	State = Stopping

--- a/server/launcher.go
+++ b/server/launcher.go
@@ -18,16 +18,55 @@
 package server
 
 import (
-	"io"
 	"net"
 	"net/http"
 	"time"
 
+	"github.com/CanonicalLtd/UCWifiConnect/utils"
+
+	"fmt"
 	"log"
 )
 
+const (
+	address = ":8080"
+)
+
+// Server running state
+const (
+	Stopped RunningState = 0 + iota
+	Starting
+	Running
+	Stopping
+)
+
+// RunningState enum defining which server is up and running
+type RunningState int
+
+// State holds current server state
+var State = Stopped
+
+var listener net.Listener
+var done chan bool
+
 type tcpKeepAliveListener struct {
 	*net.TCPListener
+}
+
+func updateStateWhenServerUp(addr string) {
+	go func() {
+		var i int
+		for i = 0; !utils.RunningOn(addr) && i < 10; i++ {
+			time.Sleep(100 * time.Millisecond)
+		}
+
+		if i < 0 {
+			log.Print("Server could not be started")
+			return
+		}
+
+		State = Running
+	}()
 }
 
 // Accept accepts incoming tcp connections
@@ -41,31 +80,54 @@ func (ln tcpKeepAliveListener) Accept() (net.Conn, error) {
 	return tc, nil
 }
 
-func listenAndServe(addr string, handler http.Handler) (io.Closer, <-chan bool, error) {
-
-	var listener net.Listener
+func listenAndServe(addr string, handler http.Handler) error {
+	State = Starting
 
 	srv := &http.Server{Addr: addr, Handler: handler}
-
 	// channel needed to communicate real server shutdown, as after calling listener.Close()
 	// it can take several milliseconds to really stop the listening.
-	done := make(chan bool)
+	done = make(chan bool)
 
-	listener, err := net.Listen("tcp", addr)
+	var err error
+	listener, err = net.Listen("tcp", addr)
 	if err != nil {
-		return nil, done, err
+		return err
 	}
 
 	// launching server in a goroutine for not blocking
 	go func() {
-		err := srv.Serve(tcpKeepAliveListener{listener.(*net.TCPListener)})
-		if err != nil {
-			log.Printf("HTTP Server closing - %v", err)
+		updateStateWhenServerUp(addr)
+
+		if listener != nil {
+			err := srv.Serve(tcpKeepAliveListener{listener.(*net.TCPListener)})
+			if err != nil {
+				log.Printf("HTTP Server closing - %v", err)
+			}
+			// notify server real stop
+			done <- true
 		}
-		// notify real server stop
-		done <- true
+
 		close(done)
+		State = Stopped
 	}()
 
-	return listener, done, nil
+	return nil
+}
+
+func stop() error {
+	State = Stopping
+
+	if listener == nil {
+		return fmt.Errorf("Already closed")
+	}
+
+	err := listener.Close()
+	if err != nil {
+		return err
+	}
+	listener = nil
+
+	<-done
+
+	return nil
 }

--- a/server/launcher_test.go
+++ b/server/launcher_test.go
@@ -47,4 +47,45 @@ func TestLaunchAndStop(t *testing.T) {
 
 func TestStates(t *testing.T) {
 
+	waitForState(Stopped)
+
+	if State != Stopped {
+		t.Error("Not in initial state")
+	}
+
+	thePort := ":14444"
+
+	err := listenAndServe(thePort, nil)
+	if err != nil {
+		t.Errorf("Start server failed: %v", err)
+	}
+
+	if State != Starting && State != Running {
+		t.Error("Not in proper start(ing) state")
+	}
+
+	waitForState(Running)
+
+	// try a bad transition
+	err = listenAndServe(thePort, nil)
+	if err == nil {
+		t.Error("An error should be thrown when trying to start an already running instance")
+	}
+
+	err = stop()
+	if err != nil {
+		t.Errorf("Stop server error: %v", err)
+	}
+
+	if State != Stopping && State != Stopped {
+		t.Error("Not in proper stop(ing) state")
+	}
+
+	waitForState(Stopped)
+
+	// try bad transitions
+	err = stop()
+	if err == nil {
+		t.Error("An error should be thrown when trying to stop a stopped instance")
+	}
 }

--- a/server/launcher_test.go
+++ b/server/launcher_test.go
@@ -27,7 +27,7 @@ func TestLaunchAndStop(t *testing.T) {
 
 	thePort := ":14444"
 
-	srv, err := listenAndServe(thePort, nil)
+	srv, done, err := listenAndServe(thePort, nil)
 	if err != nil {
 		t.Errorf("Start server failed: %v", err)
 	}
@@ -47,5 +47,7 @@ func TestLaunchAndStop(t *testing.T) {
 	if err != nil {
 		t.Errorf("Stop server error: %v", err)
 	}
+
+	<-done
 
 }

--- a/server/launcher_test.go
+++ b/server/launcher_test.go
@@ -48,6 +48,8 @@ func TestLaunchAndStop(t *testing.T) {
 		t.Errorf("Stop server error: %v", err)
 	}
 
-	<-done
-
+	d := <-done
+	if !d {
+		t.Error("Expected true value")
+	}
 }

--- a/server/launcher_test.go
+++ b/server/launcher_test.go
@@ -47,7 +47,7 @@ func TestLaunchAndStop(t *testing.T) {
 
 func TestStates(t *testing.T) {
 
-	waitForState(Stopped)
+	WaitForState(Stopped)
 
 	if State != Stopped {
 		t.Error("Not in initial state")
@@ -64,7 +64,7 @@ func TestStates(t *testing.T) {
 		t.Error("Not in proper start(ing) state")
 	}
 
-	waitForState(Running)
+	WaitForState(Running)
 
 	// try a bad transition
 	err = listenAndServe(thePort, nil)
@@ -81,7 +81,7 @@ func TestStates(t *testing.T) {
 		t.Error("Not in proper stop(ing) state")
 	}
 
-	waitForState(Stopped)
+	WaitForState(Stopped)
 
 	// try bad transitions
 	err = stop()

--- a/server/launcher_test.go
+++ b/server/launcher_test.go
@@ -27,13 +27,9 @@ func TestLaunchAndStop(t *testing.T) {
 
 	thePort := ":14444"
 
-	srv, done, err := listenAndServe(thePort, nil)
+	err := listenAndServe(thePort, nil)
 	if err != nil {
 		t.Errorf("Start server failed: %v", err)
-	}
-
-	if srv == nil {
-		t.Error("Server could not be initialzed")
 	}
 
 	// telnet to check server is alive
@@ -43,13 +39,12 @@ func TestLaunchAndStop(t *testing.T) {
 		t.Errorf("Failed to telnet localhost server at port %v: %v", thePort, err)
 	}
 
-	err = srv.Close()
+	err = stop()
 	if err != nil {
 		t.Errorf("Stop server error: %v", err)
 	}
+}
 
-	d := <-done
-	if !d {
-		t.Error("Expected true value")
-	}
+func TestStates(t *testing.T) {
+
 }

--- a/server/manager.go
+++ b/server/manager.go
@@ -20,8 +20,6 @@ package server
 import (
 	"os"
 
-	"fmt"
-
 	"github.com/CanonicalLtd/UCWifiConnect/utils"
 )
 
@@ -42,7 +40,7 @@ var Current = None
 func StartManagementServer() error {
 	if Current != None {
 		Current = None
-		return fmt.Errorf("Not in a valid status. Please stop first any other server instance before starting this one")
+		return Errorf("Not in a valid status. Please stop first any other server instance before starting this one")
 	}
 
 	// change current instance asap we manage this server
@@ -67,7 +65,7 @@ func StartManagementServer() error {
 // StartOperationalServer starts server in operational mode
 func StartOperationalServer() error {
 	if Current != None {
-		return fmt.Errorf("Not in a valid status. Please stop first any other server instance before starting this one")
+		return Errorf("Not in a valid status. Please stop first any other server instance before starting this one")
 	}
 
 	// change current instance asap we manage this server
@@ -85,7 +83,7 @@ func StartOperationalServer() error {
 // ShutdownManagementServer shutdown server management mode. If management server is not up, returns error
 func ShutdownManagementServer() error {
 	if Current != Management || (State != Running && State != Starting) {
-		return fmt.Errorf("Trying to stop management server when it is not running")
+		return Errorf("Trying to stop management server when it is not running")
 	}
 
 	err := stop()
@@ -100,7 +98,7 @@ func ShutdownManagementServer() error {
 // ShutdownOperationalServer shutdown server operational mode. If operational server is not up, returns error
 func ShutdownOperationalServer() error {
 	if Current != Operational || (State != Running && State != Starting) {
-		return fmt.Errorf("Trying to stop operational server when it is not running")
+		return Errorf("Trying to stop operational server when it is not running")
 	}
 
 	err := stop()

--- a/server/manager.go
+++ b/server/manager.go
@@ -83,7 +83,6 @@ func updateStateWhenServerUp() {
 
 // StartManagementServer starts server in management mode
 func StartManagementServer() error {
-
 	if currentlyRunning != None {
 		return fmt.Errorf("Not in a valid status. Please stop first any other server instance before starting this one")
 	}
@@ -109,7 +108,6 @@ func StartManagementServer() error {
 
 // StartOperationalServer starts server in operational mode
 func StartOperationalServer() error {
-
 	if currentlyRunning != None {
 		return fmt.Errorf("Not in a valid status. Please stop first any other server instance before starting this one")
 	}
@@ -129,7 +127,7 @@ func StartOperationalServer() error {
 
 // ShutdownManagementServer shutdown server management mode. If management server is not up, returns error
 func ShutdownManagementServer() error {
-	if currentlyRunning != Management {
+	if currentlyRunning != Management && currentlyRunning != StartingManagement {
 		return fmt.Errorf("Trying to stop management server when it is not running")
 	}
 
@@ -151,7 +149,7 @@ func ShutdownManagementServer() error {
 
 // ShutdownOperationalServer shutdown server operational mode. If operational server is not up, returns error
 func ShutdownOperationalServer() error {
-	if currentlyRunning != Operational {
+	if currentlyRunning != Operational && currentlyRunning != StartingOperational {
 		return fmt.Errorf("Trying to stop operational server when it is not running")
 	}
 

--- a/server/manager.go
+++ b/server/manager.go
@@ -19,7 +19,12 @@ package server
 
 import (
 	"io"
+	"log"
 	"os"
+
+	"time"
+
+	"fmt"
 
 	"github.com/CanonicalLtd/UCWifiConnect/utils"
 )
@@ -28,58 +33,106 @@ const (
 	address = ":8080"
 )
 
+// Server states
 const (
-	// NONE any server is up
-	NONE RunningServer = 0 + iota
-	// MANAGEMENT only management portal is up. Rest are down
-	MANAGEMENT
-	// OPERATIONAL only operational portal is up. Rest are down
-	OPERATIONAL
+	None State = 0 + iota
+	StartingManagement
+	ShuttingDownManagement
+	Management
+	StartingOperational
+	ShuttingDownOperational
+	Operational
 )
 
-// RunningServer enum defining which server is up and running
-type RunningServer int
+// State enum defining which server is up and running
+type State int
 
-var currentlyRunning = NONE
+var currentlyRunning = None
 var managementCloser io.Closer
 var operationalCloser io.Closer
 
-// Running returns RunningServer enum value saying which server is running
-func Running() RunningServer {
+// Running returns ServerState enum value saying which server is running
+func Running() State {
 	return currentlyRunning
+}
+
+func updateStateWhenServerUp() {
+	go func() {
+		var i int
+		for i = 0; !utils.RunningOn(address) && i < 10; i++ {
+			time.Sleep(100 * time.Millisecond)
+		}
+
+		if i < 0 {
+			log.Print("Server could not be started")
+			return
+		}
+
+		switch currentlyRunning {
+		case StartingManagement:
+			currentlyRunning = Management
+		case StartingOperational:
+			currentlyRunning = Operational
+		case ShuttingDownManagement:
+			fallthrough
+		case ShuttingDownOperational:
+			currentlyRunning = None
+		}
+	}()
 }
 
 // StartManagementServer starts server in management mode
 func StartManagementServer() error {
+
+	if currentlyRunning != None {
+		return fmt.Errorf("Not in a valid status. Please stop first any other server instance before starting this one")
+	}
+
+	currentlyRunning = StartingManagement
+
 	waitPath := os.Getenv("SNAP_COMMON") + "/startingApConnect"
 	var err error
 	err = utils.WriteFlagFile(waitPath)
 	if err != nil {
 		return err
 	}
+
 	managementCloser, err = listenAndServe(address, managementHandler())
 	if err != nil {
 		managementCloser = nil
 		return err
 	}
-	currentlyRunning = MANAGEMENT
+
+	updateStateWhenServerUp()
 	return nil
 }
 
 // StartOperationalServer starts server in operational mode
 func StartOperationalServer() error {
+
+	if currentlyRunning != None {
+		return fmt.Errorf("Not in a valid status. Please stop first any other server instance before starting this one")
+	}
+
+	currentlyRunning = StartingOperational
+
 	var err error
 	operationalCloser, err = listenAndServe(address, operationalHandler())
 	if err != nil {
 		operationalCloser = nil
 		return err
 	}
-	currentlyRunning = OPERATIONAL
+
+	updateStateWhenServerUp()
 	return nil
 }
 
-// ShutdownManagementServer shutdown server management mode. If server is in operational mode, it does nothing
+// ShutdownManagementServer shutdown server management mode. If management server is not up, returns error
 func ShutdownManagementServer() error {
+	if currentlyRunning != Management {
+		return fmt.Errorf("Trying to stop management server when it is not running")
+	}
+
 	if managementCloser == nil {
 		return nil
 	}
@@ -92,12 +145,16 @@ func ShutdownManagementServer() error {
 	// TODO for now we only have one server up at a time. Later, if happens
 	// that more than one can be up at the same time it would be needed manage this
 	// state changes in a better way
-	currentlyRunning = NONE
+	currentlyRunning = None
 	return nil
 }
 
-// ShutdownOperationalServer shutdown server operational mode. If server is up in management mode, it does nothing
+// ShutdownOperationalServer shutdown server operational mode. If operational server is not up, returns error
 func ShutdownOperationalServer() error {
+	if currentlyRunning != Operational {
+		return fmt.Errorf("Trying to stop operational server when it is not running")
+	}
+
 	if operationalCloser == nil {
 		return nil
 	}
@@ -110,7 +167,7 @@ func ShutdownOperationalServer() error {
 	// TODO for now we only have one server up at a time. Later, if happens
 	// that more than one can be up at the same time it would be needed manage this
 	// state changes in a better way
-	currentlyRunning = NONE
+	currentlyRunning = None
 	return nil
 }
 
@@ -124,6 +181,6 @@ func ShutdownServer() error {
 	if err2 != nil {
 		return err2
 	}
-	currentlyRunning = NONE
+	currentlyRunning = None
 	return nil
 }

--- a/server/manager_test.go
+++ b/server/manager_test.go
@@ -3,18 +3,7 @@ package server
 import (
 	"os"
 	"testing"
-	"time"
 )
-
-// needed method for testing, as server state is updated asynchronously
-func waitForState(state RunningState) bool {
-	retries := 10
-	idle := 1000 * time.Millisecond
-	for ; retries > 0 && State != state; retries-- {
-		time.Sleep(idle)
-	}
-	return State == state
-}
 
 func TestBasicServerTransitionStates(t *testing.T) {
 

--- a/server/manager_test.go
+++ b/server/manager_test.go
@@ -43,8 +43,6 @@ func TestBasicServerTransitionStates(t *testing.T) {
 
 	waitForState(None)
 
-	time.Sleep(5 * time.Second)
-
 	if err := StartOperationalServer(); err != nil {
 		t.Errorf("Error starting operational server %v", err)
 	}
@@ -52,9 +50,7 @@ func TestBasicServerTransitionStates(t *testing.T) {
 		t.Errorf("Server is not in starting or in operational status")
 	}
 
-	time.Sleep(5 * time.Second)
-
-	//waitForState(Operational)
+	waitForState(Operational)
 
 	if err := ShutdownOperationalServer(); err != nil {
 		t.Errorf("Error stopping operational server %v", err)

--- a/server/manager_test.go
+++ b/server/manager_test.go
@@ -1,0 +1,128 @@
+package server
+
+import (
+	"log"
+	"os"
+	"testing"
+	"time"
+)
+
+func waitForState(state State) {
+
+}
+
+func TestBasicServerTransitionStates(t *testing.T) {
+
+	ShutdownManagementServer()
+
+	os.Setenv("SNAP_COMMON", os.TempDir())
+
+	if Running() != None {
+		t.Errorf("Server is not in initial state")
+	}
+
+	if err := StartManagementServer(); err != nil {
+		t.Errorf("Error starting management server %v", err)
+	}
+	if Running() != Management && Running() != StartingManagement {
+		t.Errorf("Server is not in starting or in management status")
+	}
+
+	time.Sleep(1 * time.Second)
+	//OTOD TRACE
+	log.Printf("STatus: %v", Running())
+
+	if err := ShutdownManagementServer(); err != nil {
+		t.Errorf("Error stopping management server %v", err)
+	}
+	if Running() != None {
+		t.Errorf("Server is not in None status")
+	}
+
+	time.Sleep(1 * time.Second)
+
+	if err := StartOperationalServer(); err != nil {
+		t.Errorf("Error starting operational server %v", err)
+	}
+	if Running() != Operational && Running() != StartingOperational {
+		t.Errorf("Server is not in starting or in operational status")
+	}
+
+	if err := ShutdownOperationalServer(); err != nil {
+		t.Errorf("Error stopping operational server %v", err)
+	}
+	if Running() != None {
+		t.Errorf("Server is not in None status")
+	}
+}
+
+func TestEdgeServerTransitionStates(t *testing.T) {
+	os.Setenv("SNAP_COMMON", os.TempDir())
+
+	if Running() != None {
+		t.Errorf("Server is not in initial state")
+	}
+
+	if err := StartManagementServer(); err != nil {
+		t.Errorf("Error starting management server %v", err)
+	}
+	if Running() != Management && Running() != StartingManagement {
+		t.Errorf("Server is not in starting or in management status")
+	}
+
+	// start operational server without stopping management must throw an error
+	if err := StartOperationalServer; err == nil {
+		t.Errorf(`Expected an error when trying to launch one server instance having 
+		the other active`)
+	}
+	if Running() != Management {
+		t.Errorf("Server is not in management status after failed start operational server")
+	}
+
+	// stop wrong server must throw an error
+	if err := ShutdownOperationalServer; err == nil {
+		t.Errorf("Expected an error when trying to shutdown wrong server")
+	}
+	if Running() != Management {
+		t.Errorf("Server is not in management status after failed start operational server")
+	}
+
+	if err := ShutdownManagementServer(); err != nil {
+		t.Errorf("Error stopping management server %v", err)
+	}
+	if Running() != None {
+		t.Errorf("Server is not in None status")
+	}
+
+	// analog tests with operational server
+	if err := StartOperationalServer(); err != nil {
+		t.Errorf("Error starting operational server %v", err)
+	}
+	if Running() != Operational && Running() != StartingOperational {
+		t.Errorf("Server is not in starting or in operational status")
+	}
+
+	// start management server without stopping operational must throw an error
+	if err := StartManagementServer; err == nil {
+		t.Errorf(`Expected an error when trying to launch one server instance having 
+		the other active`)
+	}
+	if Running() != Operational {
+		t.Errorf("Server is not in operational status after failed start operational server")
+	}
+
+	// stop wrong server must throw an error
+	if err := ShutdownManagementServer; err == nil {
+		t.Errorf("Expected an error when trying to shutdown wrong server")
+	}
+	if Running() != Operational {
+		t.Errorf("Server is not in operational status after failed start operational server")
+	}
+
+	if err := ShutdownOperationalServer(); err != nil {
+		t.Errorf("Error stopping operational server %v", err)
+	}
+	if Running() != None {
+		t.Errorf("Server is not in None status")
+	}
+}

--- a/server/manager_test.go
+++ b/server/manager_test.go
@@ -20,7 +20,7 @@ func TestBasicServerTransitionStates(t *testing.T) {
 		t.Errorf("Server is not in starting or in management status")
 	}
 
-	waitForState(Running)
+	WaitForState(Running)
 
 	if err := ShutdownManagementServer(); err != nil {
 		t.Errorf("Error stopping management server %v", err)
@@ -30,7 +30,7 @@ func TestBasicServerTransitionStates(t *testing.T) {
 		t.Errorf("Current server is not None")
 	}
 
-	waitForState(Stopped)
+	WaitForState(Stopped)
 
 	if err := StartOperationalServer(); err != nil {
 		t.Errorf("Error starting operational server %v", err)
@@ -39,7 +39,7 @@ func TestBasicServerTransitionStates(t *testing.T) {
 		t.Errorf("Server is not in starting or in operational status")
 	}
 
-	waitForState(Running)
+	WaitForState(Running)
 
 	if err := ShutdownOperationalServer(); err != nil {
 		t.Errorf("Error stopping operational server %v", err)
@@ -63,7 +63,7 @@ func TestEdgeServerTransitionStates(t *testing.T) {
 		t.Errorf("Server is not in starting or in management status")
 	}
 
-	waitForState(Running)
+	WaitForState(Running)
 
 	// start operational server without stopping management must throw an error
 	if err := StartOperationalServer; err == nil {
@@ -89,7 +89,7 @@ func TestEdgeServerTransitionStates(t *testing.T) {
 		t.Errorf("Server is not in None status")
 	}
 
-	waitForState(Stopped)
+	WaitForState(Stopped)
 
 	// analog tests with operational server
 	if err := StartOperationalServer(); err != nil {
@@ -99,7 +99,7 @@ func TestEdgeServerTransitionStates(t *testing.T) {
 		t.Errorf("Server is not in starting or in operational status")
 	}
 
-	waitForState(Running)
+	WaitForState(Running)
 
 	// start management server without stopping operational must throw an error
 	if err := StartManagementServer; err == nil {

--- a/server/manager_test.go
+++ b/server/manager_test.go
@@ -74,6 +74,8 @@ func TestEdgeServerTransitionStates(t *testing.T) {
 		t.Errorf("Server is not in starting or in management status")
 	}
 
+	waitForState(Management)
+
 	// start operational server without stopping management must throw an error
 	if err := StartOperationalServer; err == nil {
 		t.Errorf(`Expected an error when trying to launch one server instance having 
@@ -98,6 +100,8 @@ func TestEdgeServerTransitionStates(t *testing.T) {
 		t.Errorf("Server is not in None status")
 	}
 
+	waitForState(None)
+
 	// analog tests with operational server
 	if err := StartOperationalServer(); err != nil {
 		t.Errorf("Error starting operational server %v", err)
@@ -105,6 +109,8 @@ func TestEdgeServerTransitionStates(t *testing.T) {
 	if Running() != Operational && Running() != StartingOperational {
 		t.Errorf("Server is not in starting or in operational status")
 	}
+
+	waitForState(Operational)
 
 	// start management server without stopping operational must throw an error
 	if err := StartManagementServer; err == nil {

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,7 +14,7 @@ confinement: strict
 apps:
   wifi-connect: 
     command: cmd 
-    plugs: [network, network-control, network-bind, network-manager, control]
+    plugs: [network, network-bind, network-manager, control]
   daemon:
     command: daemon
     daemon: simple

--- a/utils/fmt.go
+++ b/utils/fmt.go
@@ -1,0 +1,32 @@
+package utils
+
+import (
+	"fmt"
+)
+
+const (
+	// FmtPrefix to be included in all log traces
+	FmtPrefix = "== wifi-connect"
+)
+
+// Errorf returns a new instance implementing error interface taken a formatted string and
+// params as input
+func Errorf(format string, a ...interface{}) error {
+	return fmt.Errorf(fmt.Sprintf("%v: %v", FmtPrefix, format), a...)
+}
+
+// PkgErrorf returns a new instance implementing error interface taken a formatted string and
+// params as input
+func PkgErrorf(pkg string, format string, a ...interface{}) error {
+	return fmt.Errorf(fmt.Sprintf("%v/%v: %v", FmtPrefix, pkg, format), a...)
+}
+
+// Sprintf returns a formatted string with project prefix
+func Sprintf(format string, a ...interface{}) string {
+	return fmt.Sprintf(fmt.Sprintf("%v: %v", FmtPrefix, format), a...)
+}
+
+// PkgSprintf returns a formatted string with project prefix
+func PkgSprintf(pkg string, format string, a ...interface{}) string {
+	return fmt.Sprintf(fmt.Sprintf("%v/%v: %v", FmtPrefix, pkg, format), a...)
+}

--- a/utils/fmt_test.go
+++ b/utils/fmt_test.go
@@ -1,0 +1,52 @@
+package utils
+
+import (
+	"testing"
+)
+
+func TestErrorFormat(t *testing.T) {
+
+	msg := "Whatever message"
+	e := Errorf(msg)
+	expected := FmtPrefix + ": " + msg
+
+	if e.Error() != expected {
+		t.Errorf("Error is not well formatted, expected %v but got %v", expected, e.Error())
+	}
+}
+func TestErrorfFormat(t *testing.T) {
+
+	format := "Whatever %v"
+	detail := "message"
+	e := Errorf(format, detail)
+
+	expected := FmtPrefix + ": Whatever message"
+
+	if e.Error() != expected {
+		t.Errorf("Error is not well formatted, expected %s but got %s", expected, e.Error())
+	}
+}
+
+func TestSprintFormat(t *testing.T) {
+
+	msg := "Whatever message"
+	e := Sprintf(msg)
+	expected := FmtPrefix + ": " + msg
+
+	if e != expected {
+		t.Errorf("String is not well formatted, expected %s but got %s", expected, e)
+	}
+}
+
+func TestSprintfFormat(t *testing.T) {
+
+	format := "Whatever %v"
+	detail := "message"
+	e := Sprintf(format, detail)
+
+	expected := FmtPrefix + ": Whatever message"
+
+	if e != expected {
+		t.Errorf("String is not well formatted, expected %s but got %s", expected, e)
+	}
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -110,7 +109,6 @@ func RunningOn(address string) bool {
 	caller := telnet.StandardCaller
 	err := telnet.DialToAndCall(address, caller)
 	if err != nil {
-		log.Printf("Error checking listening at %v %v", address, err)
 		return false
 	}
 	return true

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -23,10 +23,15 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 	"sort"
 	"time"
+
+	"strings"
+
+	telnet "github.com/reiver/go-telnet"
 )
 
 // SsidsFile path to the file filled by daemon with available ssids in csv format
@@ -93,4 +98,20 @@ func ReadSsidsFile() ([]string, error) {
 		return empty, nil
 	}
 	return record, err
+}
+
+// RunningOn returns true if evaluated address is listening
+func RunningOn(address string) bool {
+
+	if strings.HasPrefix(address, ":") {
+		address = "localhost" + address
+	}
+	// telnet to check server is alive
+	caller := telnet.StandardCaller
+	err := telnet.DialToAndCall(address, caller)
+	if err != nil {
+		log.Printf("Error checking listening at %v %v", address, err)
+		return false
+	}
+	return true
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -26,9 +26,8 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"time"
-
 	"strings"
+	"time"
 
 	telnet "github.com/reiver/go-telnet"
 )


### PR DESCRIPTION
Fixes #29 
Code has been changed to separate server status from current available server. This lets us even add easily other different portals if needed, or add/remove server statuses easily.

Vars to check now are:
- server.Current (can be None, Management, Operational)
- server.State (can be Stopped, Starting, Running, Stopping) 

While starting any server a goroutine checks if the server is already started (by telnet host:port) and moves state from Starting to Running when available.
Server starts asynchronously, so that if you check state just after listenAndServe() call, maybe you still don't get desired server status as it is still in startup process. In case you want main thread to wait for certain server state, there is a server.WaitForState() available method

A bunch of new tests have been added to verify the correct state after valid or invalid transitions.