### PR TITLE
fixes #38 in which stop failed due to wait in first daemon loop

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -210,12 +210,12 @@ func main() {
 			first = false
 			//clean start require wifi AP down so we can get SSIDs
 			cw.Disable()
-			//TODO only wait if wlan0 is managed
-			//wait time period (TBD) on first run to allow wifi connections
-			time.Sleep(40000 * time.Millisecond)
 			//remove previous state flag, if any on deamon startup
 			utils.RemoveFlagFile(waitFlagPath)
 			utils.RemoveFlagFile(manualFlagPath)
+			//TODO only wait if wlan0 is managed
+			//wait time period (TBD) on first run to allow wifi connections
+			time.Sleep(40000 * time.Millisecond)
 		}
 
 		// wait 5 seconds on each iter

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -19,9 +19,9 @@ package main
 
 import (
 	"fmt"
-//	"io/ioutil"
+	"io/ioutil"
 	"os"
-//	"strings"
+	"strings"
 	"time"
 
 	"github.com/CanonicalLtd/UCWifiConnect/avahi"
@@ -57,7 +57,6 @@ func setState(s int) {
 // to path and return true, else return false.
 func scanSsids(path string, c *netman.Client) bool {
 	manage(c)
-	/*
 	SSIDs, _, _ := c.Ssids()
 	//only write SSIDs when found
 	if len(SSIDs) > 0 {
@@ -74,7 +73,6 @@ func scanSsids(path string, c *netman.Client) bool {
 			return true
 		}
 	}
-	*/
 	fmt.Println("== wifi-connect: No SSID found")
 	return false
 }
@@ -198,10 +196,6 @@ func main() {
 	managementServerDown()
 	//operationalServerDown()
 
-	//remove possibly left over flag files
-	utils.RemoveFlagFile(waitFlagPath)
-	utils.RemoveFlagFile(manualFlagPath)
-
 	for {
 		if first {
 			fmt.Println("== wifi-connect: daemon STARTING")
@@ -210,7 +204,7 @@ func main() {
 			first = false
 			//clean start require wifi AP down so we can get SSIDs
 			cw.Disable()
-			//remove previous state flag, if any on deamon startup
+			//remove previous state flags
 			utils.RemoveFlagFile(waitFlagPath)
 			utils.RemoveFlagFile(manualFlagPath)
 			//TODO only wait if wlan0 is managed

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -19,9 +19,9 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+//	"io/ioutil"
 	"os"
-	"strings"
+//	"strings"
 	"time"
 
 	"github.com/CanonicalLtd/UCWifiConnect/avahi"
@@ -57,6 +57,7 @@ func setState(s int) {
 // to path and return true, else return false.
 func scanSsids(path string, c *netman.Client) bool {
 	manage(c)
+	/*
 	SSIDs, _, _ := c.Ssids()
 	//only write SSIDs when found
 	if len(SSIDs) > 0 {
@@ -73,6 +74,7 @@ func scanSsids(path string, c *netman.Client) bool {
 			return true
 		}
 	}
+	*/
 	fmt.Println("== wifi-connect: No SSID found")
 	return false
 }


### PR DESCRIPTION
Start the daemon first loop code more cleanly by removing the flag files *before* the wait-for-external-networks to connect. Thus on entering loop after this, if the daemon has been stopped, the stop file is found and the daemon loop enters manual mode.